### PR TITLE
fixed routetable dependency error

### DIFF
--- a/HA-NAT-VMSS.json
+++ b/HA-NAT-VMSS.json
@@ -280,7 +280,10 @@
                             "routeTable": {
                               "id": "[resourceId('Microsoft.Network/routeTables', variables('routing'))]"
                             }
-                        }
+                        },
+                        "dependsOn": [
+                            "[resourceId('Microsoft.Network/routeTables', variables('routing'))]"
+                        ]
                     }
                 ]
             },


### PR DESCRIPTION
Provision failed due to dependency of route table. Route table should be created before applying on BE-subnet.